### PR TITLE
Clarify Pause on Exception setting description

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,12 +223,12 @@
 			Don't Pause on Exceptions
 		</p>
 		<p>
-			<img src="img/pauseOnUncaughtExceptionsButton.png" alt="Pause on Uncaught Exceptions" />
-			Pause on Uncaught Exceptions (including those within try/catch blocks)
+			<img src="img/pauseOnUncaughtExceptionsButton.png" alt="Pause on All Exceptions" />
+			Pause on All Exceptions (including those caught within try/catch blocks)
 		</p>
 		<p>
-			<img src="img/pauseOnUncaughtErrorsButton.png" alt="Pause on Uncaught Errors" />
-			Pause on Uncaught Errors (usually the one you want)
+			<img src="img/pauseOnUncaughtErrorsButton.png" alt="Pause on Uncaught Exceptions" />
+			Pause on Uncaught Exceptions (usually the one you want)
 		</p>
 
 		<!-- <a href="http://goo.gl/6py9m" class="docs">Breakpoints</a> -->


### PR DESCRIPTION
I find the descriptions as they are in the dev tool itself to be more clear about what they actually do; so I'd propose to call them the same way in the cheat sheet as well.
