### PR TITLE
Shortcut for "Search Across All Sources" on the Mac is wrong

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Backwards in Panel History | Ctrl + Alt + ]   | ⌘ + Alt + ]
 Forwards in Panel history  | Ctrl + Alt + [   | ⌘ + Alt + [
 Toggle Console             | Esc              | Esc
 Focus Search Box           | Ctrl + F         | ⌘ + F
-Search Across All Sources  | Ctrl + Shift + F | ⌘ + ⌘ + F
+Search Across All Sources  | Ctrl + Shift + F | ⌘ + Alt + F
 Find Previous              | Ctrl + Shift + G | ⇧ + ⌘ + G
 Find Next                  | Ctrl + G         | ⌘ + G
 Go to Source               | Ctrl + O         | ⇧ + O


### PR DESCRIPTION
The listed shortcut is `⌘ + ⌘ + F` while the shortcut that actually works is `⌘ + Alt + F`
